### PR TITLE
Fix errors in autogen.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,4 @@
-PACKAGE=stenc
-VERSION=1.0.7
-
-AC_INIT($PACKAGE, $VERSION)
+AC_INIT([stenc], [1.0.7])
 AC_CONFIG_SRCDIR([src/main.cpp])
 AM_INIT_AUTOMAKE
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([stenc], [1.0.7])
 AC_CONFIG_SRCDIR([src/main.cpp])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CHECK_HEADER([sys/types.h])


### PR DESCRIPTION
Running `./autogen.sh` from a clean checkout fails.  These fixes allow it to run successfully.