### PR TITLE
Added output of strerror to undecoded error codes

### DIFF
--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -566,7 +566,7 @@ void readIOError(int err){
 #endif
 		default:
 			if(errno!=0){
-				cerr<<"0x"<<hex<<errno<<endl;
+				cerr<<"0x"<<hex<<errno<<" "<<strerror(errno)<<endl;
 
 			}
 	}


### PR DESCRIPTION
I try to finish porting to FreeBSD and got an unhandled error code. So I just added using strerror for unhandled errors.