### PR TITLE
Remove duplicate zeroing

### DIFF
--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -262,8 +262,6 @@ bool SCSIWriteEncryptOptions(string tapeDevice, SCSIEncryptOptions* eOptions){
 	if(eOptions->keyName!=""){
 		SSP_KAD kad;
 		memset(&kad,0,sizeof(kad));
-		kad.type=0x00;
-		kad.authenticated=0;
 		//set the descriptor length to the length of the keyName
 		byteswap((unsigned char*)&kad.descriptorLength,2,eOptions->keyName.size());
 		


### PR DESCRIPTION
memset zeroes whole &kad. No need to set it's parts to zero.

Correctly pointed out by @scsirob at https://github.com/scsitape/stenc/issues/11#issuecomment-635454013.

The patch from #11 is already merged in master. This PR is an upgrade to that and it should close #11.