### PR TITLE
Use /dev/random to create a key

### DIFF
--- a/man/stenc.1
+++ b/man/stenc.1
@@ -27,7 +27,7 @@ Allows you to manage hardware encryption on SSP enabled tape devices (LTO4, LTO5
 .SH OPTIONS 
 .TP
 \fB\-g \fIlength\fR \fB\-k\fR \fB<file to save as>\fR [\fB\-kd\fR \fI<key descriptor(uKAD)>\fR]
-Generates a key file of \fIlength\fR (in bits) containing a random hexadecimal key. After entering this option, you will be required to press random keys followed by the enter key.  This will seed the random number generator so that your key is more secure.  Specify the file to save the key into with the -k option (you will need write permissions to that file location). Lastly you can enter an optional key description using the -kd flag (see \fIKEY DESCRIPTORS\fR). This key file can then be used with the \fB\-k\fR option. You should not generate a key file over an unsecured remote session. Typically, key files should be set to 256 bits (32 hexadecimal bytes), however your device may only support 128 bits.
+Generates a key file of \fIlength\fR (in bits) containing a random hexadecimal key. After entering this option, you will be required to press random keys followed by the enter key.  This will seed the random number generator so that your key is more secure. On systems with \fB/dev/random\fR, the key is automatically generated from the random content read from this file.  Specify the file to save the key into with the -k option (you will need write permissions to that file location). Lastly you can enter an optional key description using the -kd flag (see \fIKEY DESCRIPTORS\fR). This key file can then be used with the \fB\-k\fR option. You should not generate a key file over an unsecured remote session. Typically, key files should be set to 256 bits (32 hexadecimal bytes), however your device may only support 128 bits.
 
 .TP
 \fB\-f\fR \fIdevice\fR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,21 +550,35 @@ std::string timestamp(){
 
 string randomKey(int length)
 {
-	cout<<"Enter random keys on the keyboard to seed the generator."<<endl<<"End by pressing enter..."<<endl;
-	double check=0;
-	char c=0;
-	echo(false);
-	while(c!=10){
-		check+=(int)c;
-		c=getchar();
-	}
-	echo(true);
-	srand(time(NULL)+(int)check);
-	stringstream retval;
-	for (int i=0; i<length; i++)
-	{
-		retval <<HEX(rand() % 256);
-	}
-	retval << endl;
-	return retval.str();
+  unsigned char rnd;
+  stringstream retval;
+  ifstream random;
+
+  //Under Linux and AIX /dev/random provides much more cryptographically secure random output than rand()
+  random.open("/dev/random", ios::in|ios::binary);
+  if(random.is_open()){
+    for(int i=0; i<length; i++)
+    {
+      random.read(reinterpret_cast<char*>(&rnd), 1);
+      retval <<HEX(rnd);
+    }
+    random.close();
+  }else{
+    cout<<"Enter random keys on the keyboard to seed the generator."<<endl<<"End by pressing enter..."<<endl;
+    double check=0;
+    char c=0;
+    echo(false);
+    while(c!=10){
+      check+=(int)c;
+      c=getchar();
+    }
+    echo(true);
+    srand(time(NULL)+(int)check);
+    for(int i=0; i<length; i++)
+    {
+      retval <<HEX(rand() % 256);
+    }
+  }
+  retval << endl;
+  return retval.str();
 }


### PR DESCRIPTION
Use /dev/random file to create a new key instead of rand() function. It provides much more cryptographically secure random output.