### PR TITLE
Throw an error if encryption is enabled but the algorithm isn't specified

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,7 @@ string randomKey(int length);
 string timestamp();
 void echo(bool);
 ofstream logFile;
+
 //program entry point
 int main(int argc, char **argv){
 
@@ -100,6 +101,7 @@ int main(int argc, char **argv){
     int keyLength=0;
     bool detail=false;
     SCSIEncryptOptions drvOptions;
+    bool algorithmIndexSet = false;
 
     	//First load all of the options
     for(int i=1;i<argc;i++){
@@ -168,8 +170,11 @@ int main(int argc, char **argv){
                 detail=true;
         }
 	else if(thisCmd=="-a"){
-		if(nextCmd=="")errorOut("You must specify a numeric algorithm index when using the -a flag");
-                drvOptions.algorithmIndex=atoi(nextCmd.c_str()); 
+		if(nextCmd=="") {
+			errorOut("You must specify a numeric algorithm index when using the -a flag");
+		}
+		drvOptions.algorithmIndex=atoi(nextCmd.c_str());
+		algorithmIndexSet = true;
 	        i++; //skip the next argument
         }
 	else{
@@ -177,7 +182,11 @@ int main(int argc, char **argv){
 	}
 
     }
-
+	// Done reading options. Validate.
+	if (drvOptions.cryptMode != CRYPTMODE_OFF && !algorithmIndexSet) {
+		errorOut("Encryption enabled but no algorithm index was set. Use 1 for 256-bit AES.");
+	}
+	// Done validating. Execute action.
     if(action==2){//generate key
 	    if(keyFile==""){
 		errorOut("Specify file to save into with the -k argument.");
@@ -334,6 +343,7 @@ int main(int argc, char **argv){
                 errorOut("Turning encryption off for '"+tapeDrive+"' failed!");
     }
 }
+
 //exits to shell with an error message
 void errorOut(string message){
     cerr<<"Error: "<<message<<endl;


### PR DESCRIPTION
When I first tried to use this tool, I forgot to set the `-a` parameter to specify the encryption algorithm. After comparing `strace -e ioctl` output with a SCSI command reference manual, I saw that the `algorithmIndex` wasn't being set and specifying this parameter allowed the drive to accept it.

This change causes this command:
```
$ sudo stenc -f /dev/nst0 --detail -e on -k backup.key
Provided key length is 256 bits.
Key checksum is 4c7.
Turning on encryption on device '/dev/nst0'...
Sense Code:              Illegal Request (0x05)
 ASC:                    0x26
 ASCQ:                   0x00
 Additional data:        0x00000000000000000000000000000000
 Raw Sense:              0x700005000000001000000000260000ffffff8f000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
Error: Turning encryption on for '/dev/nst0' failed!
Usage: stenc --version | -g <length> -k <file> [-kd <description>] | -f <device> [--detail] [-e <on/mixed/rawread/off> [-k <file>] [-kd <description>] [-a <index>] [--protect | --unprotect] [--ckod] ]
Type 'man stenc' for more information.
```

to instead output:
```
$ sudo stenc -f /dev/st0 -e on 
Error: Encryption enabled but no algorithm index was set. Use 1 for 256-bit AES.
Usage: stenc --version | -g <length> -k <file> [-kd <description>] | -f <device> [--detail] [-e <on/mixed/rawread/off> [-k <file>] [-kd <description>] [-a <index>] [--protect | --unprotect] [--ckod] ]
Type 'man stenc' for more information.
```

if the `-e on`, `-e mixed`, or `-e rawread` options are set but no algorithm index is set.