### PR TITLE
Allow stenc to run on FreeBSD without custom kernel build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,5 +83,9 @@ AC_CHECK_PROG(PANDOC, [pandoc], [yes])
 AM_CONDITIONAL([FOUND_PANDOC], [test "x$PANDOC" = xyes])
 AM_COND_IF([FOUND_PANDOC],,[AC_MSG_ERROR([required program 'pandoc' not found.])])
 
+if test "${system}" = "FreeBSD"; then
+	  LIBS="${LIBS} -lcam"
+fi
+
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile])
 AC_OUTPUT 


### PR DESCRIPTION
Using the `sg` device on FreeBSD requires building a custom kernel, and the preferred way of issuing generic SCSI commands is via the `pass` device and the CAM library. I broke out the `#if` block in `SCSIExecute` to use CAM so `stenc` can run on unmodified FreeBSD systems.

## Test plan:
Generate a key file and enable encryption on a HP LTO drive:
```
# stenc -f /dev/sa0 -e on -k testkey.key -a 1
Provided key length is 256 bits.
Key checksum is ffffee99.
Turning on encryption on device '/dev/sa0'...
Success! See '/var/log/stenc' for a key change audit log.
```
Confirm success by observing the front panel encryption indicator is on.

Disable encryption:
```
# stenc -f /dev/sa0 -e off -a 1
Turning off encryption on device '/dev/sa0'...
Success! See '/var/log/stenc' for a key change audit log.
```
Front panel encryption indicator is clear.

Force error with invalid algorithm:
```
# stenc -f /dev/sa0 -e on -k testkey.key -a 10
Provided key length is 256 bits.
Key checksum is ffffee99.
Turning on encryption on device '/dev/sa0'...
Sense Code:              Illegal Request (0x05)
 ASC:                    0x26
 ASCQ:                   0x00
 Additional data:        0x00000000000000000000000000000000
Error: Turning encryption on for '/dev/sa0' failed!
Usage: stenc --version | -g <length> -k <file> [-kd <description>] | -f <device> [--detail] [-e <on/mixed/rawread/off> [-k <file>] [-kd <description>] [-a <index>] [--protect | --unprotect] [--ckod] ]
Type 'man stenc' for more information.
```
Sense code output matches results from stenc on Linux with the same drive.