### PR TITLE
cast to proper type

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,7 +602,7 @@ std::string randomKey(int length) {
   if (random.is_open()) {
     for (int i = 0; i < length; i++) {
       random.read(reinterpret_cast<char *>(&rnd), 1);
-      retval << std::hex << rnd;
+      retval << std::hex << std::setfill('0') << setw(2) << static_cast<int>(rnd);
     }
     random.close();
   } else {


### PR DESCRIPTION
I don't know how it happened, but in PR https://github.com/scsitape/stenc/pull/22 there is a mistake and the key is not generated correctly. I've tested a good version, but I sent the wrong. My mistake.