### PR TITLE
Remove device renaming and select default device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,26 +88,9 @@ AC_ARG_WITH([static-libgcc],
 	     ],
             [AC_MSG_RESULT(no)])
 
-
-AC_MSG_CHECKING(whether to convert rewinding device names to non-rewinding device names)
-AC_ARG_ENABLE([device-name-conversion],
-            [AS_HELP_STRING([--enable-device-name-conversion],[converts /dev/st* to /dev/st*.1 and /dev/rmt* to /dev/rmt*.1 to prevent rewinds.  Enabled by default.])],
-	    [enable_dnc=$enableval],
-	    [enable_dnc="yes"]
-	    )
-
-if test "$enable_dnc" = "yes"; then
-	  AC_MSG_RESULT(yes)
-else
-	  AC_DEFINE(DISABLE_DEVICE_NAME_CONVERSION,1,"")
-	  AC_MSG_RESULT(no)
-fi
-	  
-
 AC_CHECK_PROG(PANDOC, [pandoc], [yes])
 AM_CONDITIONAL([FOUND_PANDOC], [test "x$PANDOC" = xyes])
 AM_COND_IF([FOUND_PANDOC],,[AC_MSG_ERROR([required program 'pandoc' not found.])])
 
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile])
 AC_OUTPUT 
-


### PR DESCRIPTION
The device renaming code (/dev/stX -> /dev/nstX) looks fragile and is not portable (Linux is `st`, BSD is `sa`, AIX is `rmt`, etc.). Other tools like `mt(1)` do not try to redirect commands to the non-rewinding device; if you want to shoot yourself in the foot with `mt -f /dev/st0 eod` it will do as asked. So I think this utility should just operate with whatever device it is requested by the operator.

This change also adopts the behavior of `mt(1)` and `tar(1)` of examining the environment variable `TAPE` or the value of `DEFTAPE` in `sys/mtio.h` if the device is not explicitly specified.

This can partially address #4 and supersede #26.