### PR TITLE
Add unit test coverage of stenc output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@
 *.app
 src/stenc
 tests/scsi
+tests/output
+
+# Other outputs
+man/stenc.1
 
 # dist outputs
 *.tar.gz

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS=-std=c++17 -I${top_srcdir}/src
-TESTS=scsi
-check_PROGRAMS=scsi
+TESTS=scsi output
+check_PROGRAMS=scsi output
 scsi_SOURCES=catch.hpp scsi.cpp ${top_srcdir}/src/scsiencrypt.cpp
+output_SOURCES=catch.hpp output.cpp ${top_srcdir}/src/scsiencrypt.cpp

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -1,0 +1,112 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "config.h"
+#include "main.cpp"
+
+using namespace std::literals::string_literals;
+
+/**
+ * Compare the output of stenc given device responses
+ *
+ * These tests check the representation and interpretation of raw device data
+ * and that the program output accurately reports the meaning of the data.
+ */
+TEST_CASE("Test SCSI inquiry output", "[output]")
+{
+  const uint8_t response[] {
+    0x01, 0x80, 0x00, 0x02, 0x5b, 0x00, 0x00, 0x02,
+    0x41, 0x43, 0x4d, 0x45, 0x20, 0x20, 0x20, 0x20,
+    0x55, 0x6c, 0x74, 0x72, 0x69, 0x75, 0x6d, 0x2d,
+    0x31, 0x30, 0x30, 0x30, 0x20, 0x20, 0x20, 0x20,
+    0x31, 0x32, 0x33, 0x34, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  };
+  // note: fixed width strings in output
+  const std::string expected_output {"\
+Vendor:                  ACME    \n\
+Product ID:              Ultrium-1000    \n\
+Product Revision:        1234\n"s};
+  std::ostringstream oss;
+  print_device_inquiry(oss, reinterpret_cast<const SCSI_PAGE_INQ*>(response));
+  REQUIRE(oss.str() == expected_output);
+}
+
+TEST_CASE("SCSI get device encryption status output 1", "[output]")
+{
+  const uint8_t page[] {
+    0x00, 0x20, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  };
+  const std::string expected_output {"\
+Drive Encryption:        off\n\
+Drive Output:            Not decrypting\n\
+                         Raw encrypted data not outputted\n\
+Drive Input:             Not encrypting\n\
+Key Instance Counter:    0\n"s};
+  std::ostringstream oss;
+  print_device_status(oss, std::make_unique<SSP_DES>(reinterpret_cast<const SSP_PAGE_BUFFER*>(page)).get(), true);
+  REQUIRE(oss.str() == expected_output);
+}
+
+TEST_CASE("SCSI get device encryption status output 2", "[output]")
+{
+  const uint8_t page[] {
+    0x00, 0x20, 0x00, 0x24, 0x42, 0x02, 0x02, 0x01,
+    0x00, 0x00, 0x00, 0x01, 0x10, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0c, 0x48, 0x65, 0x6c, 0x6c,
+    0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21,
+  };
+  const std::string expected_output {"\
+Drive Encryption:        on\n\
+Drive Output:            Decrypting\n\
+                         Unencrypted data not outputted\n\
+Drive Input:             Encrypting\n\
+Key Instance Counter:    1\n\
+Encryption Algorithm:    1\n\
+Drive Key Desc.(uKAD):   Hello world!\n"s};
+  std::ostringstream oss;
+  print_device_status(oss, std::make_unique<SSP_DES>(reinterpret_cast<const SSP_PAGE_BUFFER*>(page)).get(), true);
+  REQUIRE(oss.str() == expected_output);
+}
+
+TEST_CASE("Test SCSI get next block encryption status output 1", "[output]")
+{
+  const uint8_t page[] {
+    0x00, 0x21, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+  };
+  const std::string expected_output {"\
+Volume Encryption:       Not encrypted\n"s};
+  std::ostringstream oss;
+  print_volume_status(oss, std::make_unique<SSP_NBES>(reinterpret_cast<const SSP_PAGE_BUFFER*>(page)).get());
+  REQUIRE(oss.str() == expected_output);
+}
+
+TEST_CASE("Test SCSI get next block encryption status output 2", "[output]")
+{
+  const uint8_t page[] {
+    0x00, 0x21, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x05, 0x01, 0x00, 0x00,
+    0x00, 0x01, 0x00, 0x0c, 0x48, 0x65, 0x6c, 0x6c,
+    0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21,
+  };
+  const std::string expected_output {"\
+Volume Encryption:       Encrypted and able to decrypt\n\
+Volume Algorithm:        1\n"s};
+  std::ostringstream oss;
+  print_volume_status(oss, std::make_unique<SSP_NBES>(reinterpret_cast<const SSP_PAGE_BUFFER*>(page)).get());
+  REQUIRE(oss.str() == expected_output);
+}


### PR DESCRIPTION
This increases the test coverage to include the output of stenc with regard to device data it interprets. The goal here is to make sure that even if the internal representation of SCSI data changes (e.g. with #66), then the observable output of the program remains stable.

I refactored some of the print functions to take a generic `ostream` argument so they can print to a string for comparison in tests. This also advances a goal not having deep parts of the program directly write to standard output since they can be made to write to a string stream, and then this stream can be passed back to `main` which will do the actual printing. Since these are intended to be private (static) functions in main.cpp, the test program must include main.cpp - this is unusual in normal code, but happens in test code for access to static functions.