### PR TITLE
Remove getuid root check

### DIFF
--- a/man/stenc.rst
+++ b/man/stenc.rst
@@ -20,7 +20,7 @@ SYNOPSIS
 AVAILABILITY
 ============
 
-Linux
+Linux, FreeBSD
 
 DESCRIPTION
 ===========
@@ -38,7 +38,8 @@ OPTIONS
    rewind (i.e. use */dev/nst0* instead of */dev/st0*, */dev/rmt0.1* instead
    of */dev/rmt0*). Use commands like 'cat /proc/scsi/scsi', 'lsscsi', and
    'lsdev' to determine the proper device to use. On some distros, a
-   */dev/sg* device must be used instead of a */dev/st* device.
+   */dev/sg* device must be used instead of a */dev/st* device. Typically,
+   only the superuser can access tape devices.
 
    If this is the only option specified, the status of the device will be
    displayed. To retrieve more detailed status information, add

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,9 +227,6 @@ int main(int argc, const char **argv) {
         "'--protect' is not valid when setting encryption mode to 'rawread'");
   }
 
-  if (getuid() != 0) {
-    errorOut("You must be root to read or set encryption options on a drive!");
-  }
   openlog("stenc", LOG_CONS, LOG_USER);
 
   if (action == 0) {


### PR DESCRIPTION
As noted in #64 the system can be configured to allow non-root to access tape drives. The error for a regular user is pretty understandable:
```
% ./src/stenc -f /dev/nst0 -e off
Turning off encryption on device '/dev/nst0'...
Could not open device '/dev/nst0': Permission denied
```