### PR TITLE
Do validation of options against device capabilities

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,8 +631,8 @@ int main(int argc, char **argv)
     }
 
     if (key_name.size() > ntohs(ad.maximum_ukad_length)) {
-      std::cerr << "stenc: Key descriptor exceeds maximum length of " << std::dec
-                << ntohs(ad.maximum_ukad_length) << " bytes\n";
+      std::cerr << "stenc: Key descriptor exceeds maximum length of "
+                << std::dec << ntohs(ad.maximum_ukad_length) << " bytes\n";
       std::exit(EXIT_FAILURE);
     }
 
@@ -647,6 +647,16 @@ int main(int argc, char **argv)
     if (enc_mode != scsi::encrypt_mode::on) {
       // key descriptor only valid when key is used for writing
       key_name.erase();
+    }
+
+    if (rdmc != scsi::sde_rdmc {}) {
+      auto rdmc_c {static_cast<unsigned int>(
+          ad.flags3 & scsi::algorithm_descriptor::flags3_rdmc_c_mask)};
+      if (rdmc_c == 6u << scsi::algorithm_descriptor::flags3_rdmc_c_pos ||
+          rdmc_c == 7u << scsi::algorithm_descriptor::flags3_rdmc_c_pos) {
+        std::cerr << "stenc: Device does not allow control of raw reads\n";
+        exit(EXIT_FAILURE);
+      }
     }
 
     // Write the options to the tape device

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -659,6 +659,11 @@ int main(int argc, char **argv)
       }
     }
 
+    if (ckod && !scsi::is_device_ready(tapeDrive)) {
+      std::cerr << "stenc: Cannot use --ckod when no tape media is loaded\n";
+      exit(EXIT_FAILURE);
+    }
+
     // Write the options to the tape device
     std::cerr << "Changing encryption settings for device " << tapeDrive
               << "...\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,8 +631,8 @@ int main(int argc, char **argv)
     }
 
     if (key_name.size() > ntohs(ad.maximum_ukad_length)) {
-      std::cerr << "stenc: Key descriptor exceeds maximum length " << std::dec
-                << ntohs(ad.maximum_ukad_length) << '\n';
+      std::cerr << "stenc: Key descriptor exceeds maximum length of " << std::dec
+                << ntohs(ad.maximum_ukad_length) << " bytes\n";
       std::exit(EXIT_FAILURE);
     }
 

--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 
 #include <cerrno>
 #include <cstring>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -358,16 +359,17 @@ void print_sense_data(std::ostream& os, const sense_data& sd)
 #endif
 }
 
-std::vector<const algorithm_descriptor *> read_algorithms(const page_dec& page)
+std::vector<std::reference_wrapper<const algorithm_descriptor>>
+read_algorithms(const page_dec& page)
 {
   auto it {reinterpret_cast<const std::uint8_t *>(&page.ads[0])};
   const auto end {reinterpret_cast<const std::uint8_t *>(&page) +
                   ntohs(page.length) + sizeof(page_header)};
-  std::vector<const algorithm_descriptor *> v {};
+  std::vector<std::reference_wrapper<const algorithm_descriptor>> v {};
 
   while (it < end) {
     auto elem {reinterpret_cast<const algorithm_descriptor *>(it)};
-    v.push_back(elem);
+    v.push_back(std::cref(*elem));
     it += ntohs(elem->length) + 4u; // length field + preceding 4 byte header
   }
   return v;

--- a/src/scsiencrypt.h
+++ b/src/scsiencrypt.h
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -384,16 +385,16 @@ private:
 // Extract pointers to kad structures within a variable-length page.
 // Page must have a page_header layout
 template <typename Page>
-std::vector<const kad *> read_page_kads(const Page& page)
+std::vector<std::reference_wrapper<const kad>> read_page_kads(const Page& page)
 {
   const auto start {reinterpret_cast<const std::uint8_t *>(&page)};
   auto it {start + sizeof(Page)};
   const auto end {start + ntohs(page.length) + sizeof(page_header)};
-  std::vector<const kad *> v {};
+  std::vector<std::reference_wrapper<const kad>> v {};
 
   while (it < end) {
     auto elem {reinterpret_cast<const kad *>(it)};
-    v.push_back(elem);
+    v.push_back(std::cref(*elem));
     it += ntohs(elem->length) + sizeof(kad);
   }
   return v;
@@ -422,7 +423,8 @@ make_sde(encrypt_mode enc_mode, decrypt_mode dec_mode,
 // Write set data encryption parameters to device
 void write_sde(const std::string& device, const std::uint8_t *sde_buffer);
 void print_sense_data(std::ostream& os, const sense_data& sd);
-std::vector<const algorithm_descriptor *> read_algorithms(const page_dec& page);
+std::vector<std::reference_wrapper<const algorithm_descriptor>>
+read_algorithms(const page_dec& page);
 
 } // namespace scsi
 

--- a/src/scsiencrypt.h
+++ b/src/scsiencrypt.h
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,6 @@ GNU General Public License for more details.
 #endif
 
 constexpr std::size_t SSP_PAGE_ALLOCATION = 8192;
-constexpr std::size_t SSP_UKAD_LENGTH = 0x1e;
 
 // outputs hex in a 2 digit pair
 #define HEX(x)                                                                 \
@@ -50,12 +50,38 @@ enum class encrypt_mode : std::uint8_t {
   on = 2u,
 };
 
+inline std::ostream& operator<<(std::ostream& os, encrypt_mode m)
+{
+  if (m == encrypt_mode::off) {
+    os << "off";
+  } else if (m == encrypt_mode::external) {
+    os << "external";
+  } else {
+    os << "on";
+  }
+  return os;
+}
+
 enum class decrypt_mode : std::uint8_t {
   off = 0u,
   raw = 1u,
   on = 2u,
   mixed = 3u,
 };
+
+inline std::ostream& operator<<(std::ostream& os, decrypt_mode m)
+{
+  if (m == decrypt_mode::off) {
+    os << "off";
+  } else if (m == decrypt_mode::raw) {
+    os << "raw";
+  } else if (m == decrypt_mode::on) {
+    os << "on";
+  } else {
+    os << "mixed";
+  }
+  return os;
+}
 
 enum class kad_type : std::uint8_t {
   ukad = 0u,  // unauthenticated key-associated data

--- a/tests/scsi.cpp
+++ b/tests/scsi.cpp
@@ -208,11 +208,10 @@ TEST_CASE("Interpret device encryption status page", "[scsi]")
 
   auto kads = read_page_kads(page_des);
   REQUIRE(kads.size() == 1u);
-  REQUIRE((kads[0]->flags & scsi::kad::flags_authenticated_mask) ==
-          std::byte {1u});
-  REQUIRE(ntohs(kads[0]->length) == std::strlen("Hello world!"));
-  REQUIRE(std::memcmp(kads[0]->descriptor, "Hello world!",
-                      ntohs(kads[0]->length)) == 0);
+  const scsi::kad& kd = kads[0];
+  REQUIRE((kd.flags & scsi::kad::flags_authenticated_mask) == std::byte {1u});
+  REQUIRE(ntohs(kd.length) == std::strlen("Hello world!"));
+  REQUIRE(std::memcmp(kd.descriptor, "Hello world!", ntohs(kd.length)) == 0);
 }
 
 TEST_CASE("Interpret next block encryption status page", "[scsi]")
@@ -248,11 +247,10 @@ TEST_CASE("Interpret next block encryption status page", "[scsi]")
 
   auto kads = read_page_kads(page_nbes);
   REQUIRE(kads.size() == 1u);
-  REQUIRE((kads[0]->flags & scsi::kad::flags_authenticated_mask) ==
-          std::byte {1u});
-  REQUIRE(ntohs(kads[0]->length) == std::strlen("Hello world!"));
-  REQUIRE(std::memcmp(kads[0]->descriptor, "Hello world!",
-                      ntohs(kads[0]->length)) == 0);
+  const scsi::kad& kd = kads[0];
+  REQUIRE((kd.flags & scsi::kad::flags_authenticated_mask) == std::byte {1u});
+  REQUIRE(ntohs(kd.length) == std::strlen("Hello world!"));
+  REQUIRE(std::memcmp(kd.descriptor, "Hello world!", ntohs(kd.length)) == 0);
 }
 
 TEST_CASE("Interpret data encryption capabilties page", "[scsi]")
@@ -311,7 +309,7 @@ TEST_CASE("Interpret data encryption capabilties page", "[scsi]")
   auto algorithms {read_algorithms(page_dec)};
   REQUIRE(algorithms.size() == 2u);
 
-  auto& algo1 {*algorithms[0]};
+  const scsi::algorithm_descriptor& algo1 = algorithms[0];
   REQUIRE(algo1.algorithm_index == 1u);
   REQUIRE(ntohs(algo1.length) == 20u);
   REQUIRE((algo1.flags1 & scsi::algorithm_descriptor::flags1_avfmv_mask) ==
@@ -359,7 +357,7 @@ TEST_CASE("Interpret data encryption capabilties page", "[scsi]")
   REQUIRE(ntohs(algo1.maximum_eedk_size) == 0u);
   REQUIRE(ntohl(algo1.security_algorithm_code) == 0x00010014u);
 
-  auto& algo2 {*algorithms[1]};
+  const scsi::algorithm_descriptor& algo2 = algorithms[1];
   REQUIRE(algo2.algorithm_index == 2u);
   REQUIRE(ntohs(algo2.length) == 20u);
   REQUIRE((algo2.flags1 & scsi::algorithm_descriptor::flags1_avfmv_mask) ==


### PR DESCRIPTION
Validates the algorithm index, key size, and key descriptor size against the data encryption capabilities page of the device. When possible, it is nicer to catch errors before the device returns some SCSI error code.

- If there's only one available algorithm, omitting `-a` will use the only available choice after printing a notice to stderr.
- If multiple algorithms are available, then omitting `-a` will print the choices and exit.
- Algorithm index, key size, and key descriptor size are checked against the values permitted by the device and a descriptive error message is printed.

Examples:
```
# stenc -e on -d mixed -k test_key.key
Algorithm index not specified, using 1 (AES-256-GCM-128)
# stenc -e on -d mixed -k test_key.key -a 100
stenc: Algorithm index 100 not supported by device
# stenc -e on -d mixed -k bad_key -a 1
stenc: Incorrect key size, expected 32 bytes, got 2
# stenc -e on -d mixed -k loooong_key_name -a 1
stenc: Key descriptor exceeds maximum length 32
```

Other cleanup:
- Change code to use vectors of `std::reference_wrapper` instead of raw pointers.
- Found and fixed a typo in the interpretation of the `DKAD_C` field 😬