### PR TITLE
Add bash completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS = src man tests
+SUBDIRS = src man tests bash-completion
 # EXTRA_DIST = buildconf

--- a/bash-completion/Makefile.am
+++ b/bash-completion/Makefile.am
@@ -1,0 +1,4 @@
+if ENABLE_BASH_COMPLETION
+bashcompletiondir = $(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = stenc
+endif

--- a/bash-completion/stenc
+++ b/bash-completion/stenc
@@ -1,0 +1,40 @@
+#stenc bash completion
+
+_stenc () {
+    local cur prev words cword
+    _init_completion || return
+
+    COMPREPLY=()
+
+    case $prev in
+        --version )
+            return
+            ;;
+        -f )
+            #list tape devices
+            for tape in /sys/class/scsi_tape/*;
+              do devs+="/dev/${tape##*/} ";
+            done;
+            COMPREPLY=($(compgen -W "$devs" -- "$cur"))
+            return
+            ;;
+        -e | --encrypt )
+            COMPREPLY=($(compgen -W 'off on' -- "$cur"))
+            return
+            ;;
+        -d | --decrypt )
+            COMPREPLY=($(compgen -W 'off on mixed' -- "$cur"))
+            return
+            ;;
+        -k | --keyfile )
+            _filedir
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W '-f --file -e --encrypt -d --decrypt -k --key-file -a --algorithm --allow-raw-read --no-allow-raw-read --ckod -h --help --version' -- "$cur"))
+        return
+    fi
+}
+complete -F _stenc stenc

--- a/configure.ac
+++ b/configure.ac
@@ -70,5 +70,36 @@ if test "${system}" = "FreeBSD"; then
 	  LIBS="${LIBS} -lcam"
 fi
 
-AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile])
+# BASH completion
+AC_ARG_WITH([bash-completion-dir],
+    AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+        [Install the bash auto-completion script in this directory. @<:@default=yes@:>@]),
+    [],
+    [with_bash_completion_dir=yes])
+
+if test "x$with_bash_completion_dir" = "xyes"
+then
+    extra_args=
+
+    if test "x$prefix" != "xNONE"
+    then
+        extra_args=$prefix
+    fi
+
+AC_MSG_NOTICE(extra_args is $extra_args)
+
+    PKG_CHECK_MODULES([BASH_COMPLETON], [bash-completion >= 2.0],
+        [
+          BASH_COMPLETION_DIR="$datadir/bash-completion/completions"
+        ])
+else
+    BASH_COMPLETION_DIR="$with_bash_completion_dir/"
+fi
+
+AC_MSG_NOTICE(BASH_COMPLETION_DIR is $BASH_COMPLETION_DIR)
+
+AC_SUBST([BASH_COMPLETION_DIR])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
+
+AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile bash-completion/Makefile])
 AC_OUTPUT 


### PR DESCRIPTION
Bash completion is enabled by default.
To disable bash completion install, run configure with -_-without-bash-completion-dir_ option.
`./configure --without-bash-completion-dir`
You can specify bash completion install directory with _--with-bash-completion-dir_ option.
`./configure --with-bash-completion-dir=/path`
Default install directory is $datadir/bash-completion/completions (/usr/share/bash-completion/completions)
Hints for the -f options (tape device) probably only work on Linux.