### PR TITLE
Use KAD format field

### DIFF
--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -238,7 +238,7 @@ inquiry_data get_inquiry(const std::string& device)
 std::unique_ptr<const std::uint8_t[]>
 make_sde(encrypt_mode enc_mode, decrypt_mode dec_mode,
          std::uint8_t algorithm_index, const std::vector<std::uint8_t>& key,
-         const std::string& key_name, sde_rdmc rdmc, bool ckod)
+         const std::string& key_name, kadf kad_format, sde_rdmc rdmc, bool ckod)
 {
   std::size_t length {sizeof(page_sde) + key.size()};
   if (!key_name.empty()) {
@@ -260,6 +260,7 @@ make_sde(encrypt_mode enc_mode, decrypt_mode dec_mode,
   page.encryption_mode = enc_mode;
   page.decryption_mode = dec_mode;
   page.algorithm_index = algorithm_index;
+  page.kad_format = kad_format;
   page.key_length = htons(key.size());
   std::memcpy(page.key, key.data(), key.size());
 

--- a/src/scsiencrypt.h
+++ b/src/scsiencrypt.h
@@ -92,6 +92,12 @@ enum class kad_type : std::uint8_t {
   wkkad = 4u, // wrapped key key-associated data
 };
 
+enum class kadf : std::uint8_t {
+  unspecified = 0u,
+  binary_key_name = 1u,
+  ascii_key_name = 2u,
+};
+
 // key-associated data
 struct __attribute__((packed)) kad {
   kad_type type;
@@ -137,7 +143,7 @@ struct __attribute__((packed)) page_des {
   // raw decryption mode disabled
   static constexpr auto flags_rdmd_pos {0u};
   static constexpr std::byte flags_rdmd_mask {1u << flags_rdmd_pos};
-  std::uint8_t kad_format;
+  kadf kad_format;
   std::uint16_t asdk_count;
   std::byte reserved[8];
   kad kads[];
@@ -178,7 +184,7 @@ struct __attribute__((packed)) page_sde {
   decrypt_mode decryption_mode;
   std::uint8_t algorithm_index;
   std::uint8_t key_format;
-  std::uint8_t kad_format;
+  kadf kad_format;
   std::byte reserved[7];
   std::uint16_t key_length;
   std::uint8_t key[];
@@ -187,9 +193,9 @@ static_assert(sizeof(page_sde) == 20u);
 
 enum class sde_rdmc : std::uint8_t {
   algorithm_default = 0u << page_sde::flags_rdmc_pos,
-  enabled = 2u << page_sde::flags_rdmc_pos,  // corresponds to --unprotect
+  enabled = 2u << page_sde::flags_rdmc_pos,  // corresponds to --allow-raw-read
                                              // command line option
-  disabled = 3u << page_sde::flags_rdmc_pos, // corresponds to --protect command
+  disabled = 3u << page_sde::flags_rdmc_pos, // corresponds to --no-allow-raw-read command
                                              // line option
 };
 
@@ -213,7 +219,7 @@ struct __attribute__((packed)) page_nbes {
   // raw decryption mode disabled status
   static constexpr auto flags_rdmds_pos {0u};
   static constexpr std::byte flags_rdmds_mask {1u << flags_rdmds_pos};
-  std::uint8_t kad_format;
+  kadf kad_format;
   kad kads[];
 };
 static_assert(sizeof(page_nbes) == 16u);
@@ -419,7 +425,7 @@ void get_dec(const std::string& device, std::uint8_t *buffer,
 std::unique_ptr<const std::uint8_t[]>
 make_sde(encrypt_mode enc_mode, decrypt_mode dec_mode,
          std::uint8_t algorithm_index, const std::vector<std::uint8_t>& key,
-         const std::string& key_name, sde_rdmc rdmc, bool ckod);
+         const std::string& key_name, kadf key_format, sde_rdmc rdmc, bool ckod);
 // Write set data encryption parameters to device
 void write_sde(const std::string& device, const std::uint8_t *sde_buffer);
 void print_sense_data(std::ostream& os, const sense_data& sd);

--- a/tests/scsi.cpp
+++ b/tests/scsi.cpp
@@ -27,7 +27,8 @@ TEST_CASE("Disable encryption command", "[scsi]")
       0x00, // decryption mode
       0x01, // algorithm index
       0x00, // key format
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [8]
+      0x00, // KAD format
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [7]
       0x00, 0x00 // key length
       // clang-format on
   };
@@ -35,9 +36,9 @@ TEST_CASE("Disable encryption command", "[scsi]")
   std::vector<std::uint8_t> key {};
   std::string key_name {};
 
-  auto page_buffer {scsi::make_sde(scsi::encrypt_mode::off,
-                                   scsi::decrypt_mode::off, 1u, key, key_name,
-                                   scsi::sde_rdmc::algorithm_default, false)};
+  auto page_buffer {scsi::make_sde(
+      scsi::encrypt_mode::off, scsi::decrypt_mode::off, 1u, key, key_name,
+      scsi::kadf::unspecified, scsi::sde_rdmc::algorithm_default, false)};
   auto& page {reinterpret_cast<const scsi::page_sde&>(*page_buffer.get())};
   REQUIRE(sizeof(scsi::page_header) + ntohs(page.length) == sizeof(expected));
   REQUIRE(std::memcmp(&page, expected, sizeof(expected)) == 0);
@@ -55,7 +56,8 @@ TEST_CASE("Enable encryption command", "[scsi]")
       0x02, // decryption mode
       0x01, // algorithm index
       0x00, // key format
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [8]
+      0x00, // KAD format
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [7]
       0x00, 0x20, // key length
       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
       0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
@@ -71,9 +73,9 @@ TEST_CASE("Enable encryption command", "[scsi]")
   };
   std::string key_name {};
 
-  auto page_buffer {scsi::make_sde(scsi::encrypt_mode::on,
-                                   scsi::decrypt_mode::on, 1u, key, key_name,
-                                   scsi::sde_rdmc::algorithm_default, false)};
+  auto page_buffer {scsi::make_sde(
+      scsi::encrypt_mode::on, scsi::decrypt_mode::on, 1u, key, key_name,
+      scsi::kadf::unspecified, scsi::sde_rdmc::algorithm_default, false)};
   auto& page {reinterpret_cast<const scsi::page_sde&>(*page_buffer.get())};
   REQUIRE(sizeof(scsi::page_header) + ntohs(page.length) == sizeof(expected));
   REQUIRE(std::memcmp(&page, expected, sizeof(expected)) == 0);
@@ -91,7 +93,8 @@ TEST_CASE("Enable encryption command with options", "[scsi]")
       0x02, // decryption mode
       0x01, // algorithm index
       0x00, // key format
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [8]
+      0x01, // KAD format
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [7]
       0x00, 0x20, // key length
       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
       0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
@@ -107,9 +110,9 @@ TEST_CASE("Enable encryption command with options", "[scsi]")
   };
   std::string key_name {};
 
-  auto page_buffer {scsi::make_sde(scsi::encrypt_mode::on,
-                                   scsi::decrypt_mode::on, 1u, key, key_name,
-                                   scsi::sde_rdmc::enabled, true)};
+  auto page_buffer {scsi::make_sde(
+      scsi::encrypt_mode::on, scsi::decrypt_mode::on, 1u, key, key_name,
+      scsi::kadf::binary_key_name, scsi::sde_rdmc::enabled, true)};
   auto& page {reinterpret_cast<const scsi::page_sde&>(*page_buffer.get())};
   REQUIRE(sizeof(scsi::page_header) + ntohs(page.length) == sizeof(expected));
   REQUIRE(std::memcmp(&page, expected, sizeof(expected)) == 0);
@@ -127,7 +130,8 @@ TEST_CASE("Enable encryption command with key name", "[scsi]")
       0x02, // decryption mode
       0x01, // algorithm index
       0x00, // key format
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [8]
+      0x02, // KAD format
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved [7]
       0x00, 0x20, // key length
       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
       0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
@@ -148,9 +152,9 @@ TEST_CASE("Enable encryption command with key name", "[scsi]")
   };
   std::string key_name {"Hello world!"s};
 
-  auto page_buffer {scsi::make_sde(scsi::encrypt_mode::on,
-                                   scsi::decrypt_mode::on, 1u, key, key_name,
-                                   scsi::sde_rdmc::algorithm_default, false)};
+  auto page_buffer {scsi::make_sde(
+      scsi::encrypt_mode::on, scsi::decrypt_mode::on, 1u, key, key_name,
+      scsi::kadf::ascii_key_name, scsi::sde_rdmc::algorithm_default, false)};
   auto& page {reinterpret_cast<const scsi::page_sde&>(*page_buffer.get())};
   REQUIRE(sizeof(scsi::page_header) + ntohs(page.length) == sizeof(expected));
   REQUIRE(std::memcmp(&page, expected, sizeof(expected)) == 0);


### PR DESCRIPTION
Most recent tape drives allow describing the format of the KAD field, in the case of stenc, always a text string. If the data encryption capabilities page says it is allowed, the format type will be set. This is a nice-to-have, and recommended in the HP software integration guide.

![image](https://user-images.githubusercontent.com/655085/172073097-97a0dc13-03df-46c8-89a5-9ee9631c82f1.png)