### PR TITLE
Fix FreeBSD build issues

### DIFF
--- a/bash-completion/stenc
+++ b/bash-completion/stenc
@@ -12,10 +12,14 @@ _stenc () {
             ;;
         -f )
             #list tape devices
-            for tape in /sys/class/scsi_tape/*;
-              do devs+="/dev/${tape##*/} ";
-            done;
-            COMPREPLY=($(compgen -W "$devs" -- "$cur"))
+            if [[ $(uname) == Linux ]]; then
+                for tape in /sys/class/scsi_tape/*;
+                  do devs+="/dev/${tape##*/} ";
+                done;
+                COMPREPLY=($(compgen -W "$devs" -- "$cur"))
+            else
+                _filedir
+            fi
             return
             ;;
         -e | --encrypt )
@@ -26,7 +30,7 @@ _stenc () {
             COMPREPLY=($(compgen -W 'off on mixed' -- "$cur"))
             return
             ;;
-        -k | --keyfile )
+        -k | --key-file )
             _filedir
             return
             ;;

--- a/configure.ac
+++ b/configure.ac
@@ -71,34 +71,14 @@ if test "${system}" = "FreeBSD"; then
 fi
 
 # BASH completion
-AC_ARG_WITH([bash-completion-dir],
-    AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
-        [Install the bash auto-completion script in this directory. @<:@default=yes@:>@]),
-    [],
-    [with_bash_completion_dir=yes])
+PKG_CHECK_VAR([BASH_COMPLETION_DIR], [bash-completion >= 2.0], [completionsdir],
+    [
+        with_bash_completion_dir=yes;
+        AC_MSG_NOTICE(BASH_COMPLETION_DIR is $BASH_COMPLETION_DIR);
+        AC_SUBST([BASH_COMPLETION_DIR])
+    ],
+    [with_bash_completion_dir=no])
 
-if test "x$with_bash_completion_dir" = "xyes"
-then
-    extra_args=
-
-    if test "x$prefix" != "xNONE"
-    then
-        extra_args=$prefix
-    fi
-
-AC_MSG_NOTICE(extra_args is $extra_args)
-
-    PKG_CHECK_MODULES([BASH_COMPLETON], [bash-completion >= 2.0],
-        [
-          BASH_COMPLETION_DIR="$datadir/bash-completion/completions"
-        ])
-else
-    BASH_COMPLETION_DIR="$with_bash_completion_dir/"
-fi
-
-AC_MSG_NOTICE(BASH_COMPLETION_DIR is $BASH_COMPLETION_DIR)
-
-AC_SUBST([BASH_COMPLETION_DIR])
 AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
 
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile bash-completion/Makefile])

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -5,7 +5,7 @@ EXTRA_DIST = stenc.rst
 all: stenc.1
 
 stenc.1: stenc.rst
-	pandoc --standalone --to man $< -o $@
+	pandoc --standalone --to man $? -o $@
 
 clean:
 	rm -f stenc.1


### PR DESCRIPTION
Fix some FreeBSD problems:
- Only Linux has `/sys` filesystem
- unbreak configure script pkg-config check on FreeBSD
- `$<` only works with suffix rules on FreeBSD

Removed `--with-bash-completion-dir` since the correct system value can be gotten from `pkg-config` variables, see `./configure --help`:
```
  BASH_COMPLETION_DIR
              value of completionsdir for bash-completion >= 2.0, overriding
              pkg-config
```