### PR TITLE
Issues in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Get the source code and compile
 -------------------------------
 
 ```
-git clone git@github.com:scsitape/stenc.git
+git clone https://github.com/christianreiss/stenc.git
 cd stenc/
 autoreconf --install
 ./autogen.sh && ./configure  
@@ -43,7 +43,7 @@ Usage example
 
 
 ```
-$ stenc -f /dev/nst0 --detail
+$ stenc -f /dev/nst0
 Status for /dev/nst0
 --------------------------------------------------
 Device Mfg:              TANDBERG

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Get the source code and compile
 -------------------------------
 
 ```
-git clone https://github.com/christianreiss/stenc.git
+git clone https://github.com/scsitape/stenc.git
 cd stenc/
 autoreconf --install
 ./autogen.sh && ./configure  


### PR DESCRIPTION
There are two minor issues in the readme:

- The cloning url only works for people who have their access keys at hand/ ready. This method allows everyone to clone.
- The "--detail" flag is unkown in the current release.