### PR TITLE
Update status output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,17 @@ Usage example
 
 ```
 $ stenc -f /dev/nst0
-Status for /dev/nst0
+Status for /dev/nst0 (TANDBERG LTO-6 HH 3579)
 --------------------------------------------------
-Device Mfg:              TANDBERG
-Product ID:              LTO-6 HH        
-Product Revision:        3579
-Drive Encryption:        on
-Drive Output:            Decrypting
-                         Unencrypted data not outputted
-Drive Input:             Encrypting
-                         Protecting from raw read
-Key Instance Counter:    1
-Encryption Algorithm:    1
-Drive Key Desc.(uKAD):   mykey20170113
+Reading:                         Decrypting (AES-256-GCM-128)
+Writing:                         Encrypting (AES-256-GCM-128)
+                                 Protecting from raw read
+Key instance counter:            1
+Drive key desc. (U-KAD):         mykey20170113
+Supported algorithms:
+1    AES-256-GCM-128
+     Key descriptors allowed, maximum 32 bytes
+     Raw decryption mode allowed, raw read enabled by default
 ```
 
 

--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -204,8 +204,8 @@ bool is_device_ready(const std::string& device)
   }
 }
 
-void get_des(const std::string& device, std::uint8_t *buffer,
-             std::size_t length)
+const page_des& get_des(const std::string& device, std::uint8_t *buffer,
+                        std::size_t length)
 {
   const std::uint8_t spin_des_command[] {
       SSP_SPIN_OPCODE,
@@ -220,10 +220,10 @@ void get_des(const std::string& device, std::uint8_t *buffer,
   };
   scsi_execute(device, spin_des_command, sizeof(spin_des_command), buffer,
                length, scsi_direction::from_device);
+  auto& page {reinterpret_cast<const page_des&>(*buffer)};
 
 #if defined(DEBUGSCSI)
   std::cerr << "SCSI Response: ";
-  auto& page {reinterpret_cast<const page_des&>(*buffer)};
   std::uint8_t *it {buffer};
   const std::uint8_t *end {
       buffer + std::min(length, sizeof(page_header) + ntohs(page.length))};
@@ -232,10 +232,12 @@ void get_des(const std::string& device, std::uint8_t *buffer,
   }
   std::cerr << '\n';
 #endif
+
+  return page;
 }
 
-void get_nbes(const std::string& device, std::uint8_t *buffer,
-              std::size_t length)
+const page_nbes& get_nbes(const std::string& device, std::uint8_t *buffer,
+                          std::size_t length)
 {
   const std::uint8_t spin_nbes_command[] {
       SSP_SPIN_OPCODE,
@@ -250,10 +252,10 @@ void get_nbes(const std::string& device, std::uint8_t *buffer,
   };
   scsi_execute(device, spin_nbes_command, sizeof(spin_nbes_command), buffer,
                length, scsi_direction::from_device);
+  auto& page {reinterpret_cast<const page_nbes&>(*buffer)};
 
 #if defined(DEBUGSCSI)
   std::cerr << "SCSI Response: ";
-  auto& page {reinterpret_cast<const page_nbes&>(*buffer)};
   std::uint8_t *it {buffer};
   const std::uint8_t *end {
       buffer + std::min(length, sizeof(page_header) + ntohs(page.length))};
@@ -262,10 +264,12 @@ void get_nbes(const std::string& device, std::uint8_t *buffer,
   }
   std::cerr << '\n';
 #endif
+
+  return page;
 }
 
-void get_dec(const std::string& device, std::uint8_t *buffer,
-             std::size_t length)
+const page_dec& get_dec(const std::string& device, std::uint8_t *buffer,
+                        std::size_t length)
 {
   const std::uint8_t spin_dec_command[] {
       SSP_SPIN_OPCODE,
@@ -280,10 +284,10 @@ void get_dec(const std::string& device, std::uint8_t *buffer,
   };
   scsi_execute(device, spin_dec_command, sizeof(spin_dec_command), buffer,
                length, scsi_direction::from_device);
+  auto& page {reinterpret_cast<const page_dec&>(*buffer)};
 
 #if defined(DEBUGSCSI)
   std::cerr << "SCSI Response: ";
-  auto& page {reinterpret_cast<const page_dec&>(*buffer)};
   std::uint8_t *it {buffer};
   const std::uint8_t *end {
       buffer + std::min(length, sizeof(page_header) + ntohs(page.length))};
@@ -292,6 +296,8 @@ void get_dec(const std::string& device, std::uint8_t *buffer,
   }
   std::cerr << '\n';
 #endif
+
+  return page;
 }
 
 inquiry_data get_inquiry(const std::string& device)

--- a/src/scsiencrypt.h
+++ b/src/scsiencrypt.h
@@ -320,9 +320,9 @@ struct __attribute__((packed)) inquiry_data {
   std::byte flags3;
   std::byte flags4;
   std::byte flags5;
-  char vendor[8];
-  char product_id[16];
-  char product_rev[4];
+  std::array<char, 8> vendor;
+  std::array<char, 16> product_id;
+  std::array<char, 4> product_rev;
   std::uint8_t vendor_specific[20];
   std::byte reserved1[2];
   std::uint16_t version_descriptor[8];
@@ -415,14 +415,14 @@ bool is_device_ready(const std::string& device);
 // Get SCSI inquiry data from device
 inquiry_data get_inquiry(const std::string& device);
 // Get data encryption status page
-void get_des(const std::string& device, std::uint8_t *buffer,
-             std::size_t length);
+const page_des& get_des(const std::string& device, std::uint8_t *buffer,
+                        std::size_t length);
 // Get next block encryption status page
-void get_nbes(const std::string& device, std::uint8_t *buffer,
-              std::size_t length);
+const page_nbes& get_nbes(const std::string& device, std::uint8_t *buffer,
+                          std::size_t length);
 // Get device encryption capabilities
-void get_dec(const std::string& device, std::uint8_t *buffer,
-             std::size_t length);
+const page_dec& get_dec(const std::string& device, std::uint8_t *buffer,
+                        std::size_t length);
 // Fill out a set data encryption page with parameters.
 // Result is allocated and returned as a std::unique_ptr and should
 // be sent to the device using scsi::write_sde


### PR DESCRIPTION
Update the status output format with some improvements for brevity and understanding:
1. move the vendor and product info to a single line following the device name. These fields in `scsiencrypt.h` are now declared with `std::array` to make it a one-liner in modern C++ to rtrim and print them.
2. replace `Drive input: Encrypting` with `Writing: Encrypting` and `Drive output: Decrypting` with `Reading: Encrypting`. This better matches how a tape drive is typically used in a UNIX command or pipe (since "Drive input" refers the action that is done when the drive is used as the *output* file of command such as `dd if=src of=/dev/nst0`)
3. change `Volume Encryption: Encrypted` to `Current block status: Encrypted`. "Volume" is not a term used in `mt` or other tape programs. The SCSI data is being printed is actually called "next block encryption status" since it refers to the block following the current tape position.
4. Print algorithm name (e.g. AES-256-GCM-128) instead of the algorithm index where possible.

Other changes:
1. update README to reflect new output
2. test file `output.cpp` updated for new output
3. reduce code duplication in `scsiencrypt.cpp` debug output with a new function `print_buffer`. Including in this PR to reduce merge conflicts.

Follow-on PR with fixing include headers using `include-what-you-use` to follow.