### PR TITLE
Update header includes using include-what-you-use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,18 +1,15 @@
 # SPDX-FileCopyrightText: 2022 stenc authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-AC_INIT([stenc],[1.1.1])
+AC_INIT([stenc],[2.0.0])
 AC_CONFIG_SRCDIR([src/main.cpp])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
-AC_CONFIG_HEADERS([config.h])
-AC_CHECK_HEADER([sys/types.h])
-AC_CHECK_HEADER([sys/machine.h])
+AC_CONFIG_HEADERS([config.h])]
+AC_CHECK_HEADERS
+AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
 # Checks for programs
 AC_PROG_CXX
-
-# Checks for header files.
-AC_PROG_EGREP
 
 AC_MSG_CHECKING(whether to output raw SCSI messages)
 AC_ARG_WITH([scsi-debug],

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,31 +20,38 @@ GNU General Public License for more details.
 #include <config.h>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <iomanip>
-#include <ios>
 #include <iostream>
 #include <limits>
 #include <map>
+#include <memory>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
+#include <errno.h>
 #include <getopt.h>
+#include <string.h>
 #include <sys/mtio.h>
-#include <sys/stat.h>
 #include <syslog.h>
 #include <termios.h>
 
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
+#if HAVE_ARPA_INET_H
+#include <arpa/inet.h>
 #endif
-#ifdef HAVE_STRING_H
-#include <string.h>
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -383,7 +390,7 @@ int main(int argc, char **argv)
   std::optional<scsi::encrypt_mode> enc_mode;
   std::optional<scsi::decrypt_mode> dec_mode;
   std::optional<std::uint8_t> algorithm_index;
-  std::vector<uint8_t> key;
+  std::vector<std::uint8_t> key;
   std::string key_name;
   scsi::sde_rdmc rdmc {};
   scsi::kadf kad_format {};

--- a/src/scsiencrypt.cpp
+++ b/src/scsiencrypt.cpp
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <type_traits>
 
 #include <fcntl.h>
@@ -36,7 +37,6 @@ GNU General Public License for more details.
 #endif
 
 #if defined(OS_LINUX)
-#include <scsi/scsi.h>
 #include <scsi/sg.h>
 constexpr unsigned int SCSI_TIMEOUT {5000u};
 #elif defined(OS_FREEBSD)

--- a/src/scsiencrypt.h
+++ b/src/scsiencrypt.h
@@ -20,8 +20,9 @@ GNU General Public License for more details.
 #ifndef _SCSIENC_H
 #define _SCSIENC_H
 
+#include <config.h>
+
 #include <array>
-#include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -29,15 +30,14 @@ GNU General Public License for more details.
 #include <ostream>
 #include <string>
 #include <vector>
+#include <stdexcept>
+#include <utility>
 
+#if HAVE_ARPA_INET_H
 #include <arpa/inet.h>
-
-#ifdef HAVE_SYS_MACHINE_H
-#include <sys/machine.h>
 #endif
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 
 namespace scsi {

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -5,11 +5,13 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include <memory>
+#include <cstdint>
+#include <map>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <vector>
 
-#include "config.h"
 #include "main.cpp"
 
 using namespace std::literals::string_literals;
@@ -58,7 +60,7 @@ TEST_CASE("Test SCSI inquiry output", "[output]")
 TEST_CASE("SCSI get device encryption status output 1", "[output]")
 {
   std::map<std::uint8_t, std::string> algorithms {
-    { 1, "AES-256-GCM-128"s },
+      {1, "AES-256-GCM-128"s},
   };
   const std::uint8_t page[] {
       0x00, 0x20, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -69,14 +71,15 @@ Reading:                         Not decrypting\n\
 Writing:                         Not encrypting\n\
 Key instance counter:            0\n"s};
   std::ostringstream oss;
-  print_device_status(oss, reinterpret_cast<const scsi::page_des&>(page), algorithms);
+  print_device_status(oss, reinterpret_cast<const scsi::page_des&>(page),
+                      algorithms);
   REQUIRE(oss.str() == expected_output);
 }
 
 TEST_CASE("SCSI get device encryption status output 2", "[output]")
 {
   std::map<std::uint8_t, std::string> algorithms {
-    { 1, "AES-256-GCM-128"s },
+      {1, "AES-256-GCM-128"s},
   };
   const std::uint8_t page[] {
       0x00, 0x20, 0x00, 0x24, 0x42, 0x02, 0x02, 0x01, 0x00, 0x00,
@@ -91,14 +94,15 @@ Writing:                         Encrypting (AES-256-GCM-128)\n\
 Key instance counter:            1\n\
 Drive key desc. (U-KAD):         Hello world!\n"s};
   std::ostringstream oss;
-  print_device_status(oss, reinterpret_cast<const scsi::page_des&>(page), algorithms);
+  print_device_status(oss, reinterpret_cast<const scsi::page_des&>(page),
+                      algorithms);
   REQUIRE(oss.str() == expected_output);
 }
 
 TEST_CASE("Test SCSI get next block encryption status output 1", "[output]")
 {
   std::map<std::uint8_t, std::string> algorithms {
-    { 1, "AES-256-GCM-128"s },
+      {1, "AES-256-GCM-128"s},
   };
   const std::uint8_t page[] {
       0x00, 0x21, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00,
@@ -107,14 +111,15 @@ TEST_CASE("Test SCSI get next block encryption status output 1", "[output]")
   const std::string expected_output {"\
 Current block status:            Not encrypted\n"s};
   std::ostringstream oss;
-  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page), algorithms);
+  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page),
+                     algorithms);
   REQUIRE(oss.str() == expected_output);
 }
 
 TEST_CASE("Test SCSI get next block encryption status output 2", "[output]")
 {
   std::map<std::uint8_t, std::string> algorithms {
-    { 1, "AES-256-GCM-128"s },
+      {1, "AES-256-GCM-128"s},
   };
   const std::uint8_t page[] {
       0x00, 0x21, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -124,14 +129,15 @@ TEST_CASE("Test SCSI get next block encryption status output 2", "[output]")
   const std::string expected_output {"\
 Current block status:            Encrypted and able to decrypt (AES-256-GCM-128)\n"s};
   std::ostringstream oss;
-  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page), algorithms);
+  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page),
+                     algorithms);
   REQUIRE(oss.str() == expected_output);
 }
 
 TEST_CASE("Test SCSI get next block encryption status output 3", "[output]")
 {
   std::map<std::uint8_t, std::string> algorithms {
-    { 1, "AES-256-GCM-128"s },
+      {1, "AES-256-GCM-128"s},
   };
   const std::uint8_t page[] {
       0x00, 0x21, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -142,7 +148,8 @@ TEST_CASE("Test SCSI get next block encryption status output 3", "[output]")
 Current block status:            Encrypted, key missing or invalid (AES-256-GCM-128)\n\
 Current block key desc. (U-KAD): Hello world!\n"s};
   std::ostringstream oss;
-  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page), algorithms);
+  print_block_status(oss, reinterpret_cast<const scsi::page_nbes&>(page),
+                     algorithms);
   REQUIRE(oss.str() == expected_output);
 }
 

--- a/tests/scsi.cpp
+++ b/tests/scsi.cpp
@@ -5,10 +5,22 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include "config.h"
-#include "scsiencrypt.h"
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
 
+#if HAVE_ARPA_INET_H
 #include <arpa/inet.h>
+#endif
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+
+#include "scsiencrypt.h"
 
 using namespace std::literals::string_literals;
 


### PR DESCRIPTION
Ran `include-what-you-use` and `clang-format` on sources. `iwyu` isn't perfect; it suggested I remove `<fstream>` and `<sstream>` which breaks compilation. This may be because of small differences between LLVM and GCC internals and standard library implementations.

Compilation and tests succeed on Debian bullseye and FreeBSD 13.2.

Updated `configure.ac` with 2.0.0 project version, and added checks for `<arpa/inet.h>` and `<netinet/in.h>` based on this note from `man ntohs`: "Some systems require the inclusion of <netinet/in.h> instead of <arpa/inet.h>."

Found one instance where we forgot `std::` in front of `uint8_t`