### PR TITLE
Added nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762482733,
+        "narHash": "sha256-g/da4FzvckvbiZT075Sb1/YDNDr+tGQgh4N8i5ceYMg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e1ebeec86b771e9d387dd02d82ffdc77ac753abc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "SCSI Tape Encryption Manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages = nixpkgs.lib.genAttrs ["x86_64-linux"] (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      stenc = pkgs.stdenv.mkDerivation {
+        pname = "stenc";
+        version = "2.0.1";
+        src = ./.;
+        
+        nativeBuildInputs = with pkgs; [
+          autoreconfHook 
+          pandoc 
+          pkg-config 
+        ];
+
+        meta = with pkgs.lib; {
+          description = "SCSI Tape Encryption Manager";
+          license = licenses.gpl2;
+          maintainers = with maintainers; [ llamato ];
+          platforms = platforms.unix;
+        };
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ 
+          autoconf
+          automake
+          libtool
+          pkg-config
+          pandoc
+        ];
+
+        buildInputs = with pkgs; [
+          bash-completion
+          clang
+          gcc
+          gdb
+        ];
+
+        shellHook = ''
+          autoreconf -fi
+          ./configure
+          make
+        '';
+      };
+    });
+
+    defaultPackage = {
+      x86_64-linux = self.packages.x86_64-linux.stenc;
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a configuration file for the nix package manager. 

This enables users of the nix package manager to build the project using a single nix build command and or install stenc directly from source using the nix package manager.

The code was tested by installing stenc on an x86-64-linux NixOs machine with a Quantum LTO6 tape drive attached via SAS. Stenc is as far as I can tell fully functional.

